### PR TITLE
Add autocorrect transcriptions feature for voice recordings

### DIFF
--- a/app/jobs/autocorrect_transcriptions_job.rb
+++ b/app/jobs/autocorrect_transcriptions_job.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Corrects dictionary entry transcriptions using the full transcript on the
+# VoiceRecording, then re-translates any entries that were updated.
+class AutocorrectTranscriptionsJob < ApplicationJob
+  queue_as :default
+
+  def perform(voice_recording_id)
+    voice_recording = VoiceRecording.find(voice_recording_id)
+
+    updated_count = AutocorrectTranscriptionsService.new(voice_recording).process
+    return unless updated_count&.positive?
+
+    Rails.logger.info("AutocorrectTranscriptionsJob: corrected #{updated_count} entries for recording #{voice_recording_id}, re-translating")
+
+    voice_recording.dictionary_entries
+      .where(accuracy_status: :unconfirmed, translation: [nil, ""])
+      .order(:region_start)
+      .each(&:translate)
+  end
+end

--- a/app/policies/voice_recording_policy.rb
+++ b/app/policies/voice_recording_policy.rb
@@ -35,6 +35,10 @@ class VoiceRecordingPolicy < ApplicationPolicy
     user&.admin?
   end
 
+  def autocorrect?
+    user&.admin?
+  end
+
   def import_status?
     # Same permission as show - anyone can check import status
     true

--- a/app/services/autocorrect_transcriptions_service.rb
+++ b/app/services/autocorrect_transcriptions_service.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+# Uses the full transcript stored on a VoiceRecording to correct the
+# machine-generated word_or_phrase on each associated DictionaryEntry.
+#
+# The entries are ordered by region_start. Confirmed entries are skipped.
+# Returns the number of entries corrected, or nil on failure.
+class AutocorrectTranscriptionsService
+  def initialize(voice_recording)
+    @voice_recording = voice_recording
+  end
+
+  def process
+    return unless @voice_recording.transcription.present?
+
+    entries = @voice_recording.dictionary_entries.order(:region_start).to_a
+    return 0 if entries.empty?
+
+    corrected_texts = fetch_corrected_segments(entries)
+    return unless corrected_texts.present?
+
+    unless corrected_texts.size == entries.size
+      Rails.logger.error(
+        "AutocorrectTranscriptionsService: expected #{entries.size} segments, got #{corrected_texts.size}"
+      )
+      return
+    end
+
+    updated_count = 0
+    entries.zip(corrected_texts).each do |entry, corrected_text|
+      next if entry.confirmed?
+      next if corrected_text.blank?
+      next if corrected_text.strip == entry.word_or_phrase&.strip
+
+      entry.update!(word_or_phrase: corrected_text.strip, translation: nil, status: :transcribed)
+      updated_count += 1
+    end
+
+    updated_count
+  rescue => e
+    Rails.logger.error("AutocorrectTranscriptionsService failed: #{e.message}")
+    nil
+  end
+
+  private
+
+  def fetch_corrected_segments(entries)
+    existing = entries.map.with_index(1) do |entry, i|
+      "#{i}. #{entry.word_or_phrase.presence || "[blank]"}"
+    end.join("\n")
+
+    prompt = <<~PROMPT
+      You are an Irish language expert correcting automatic speech recognition (ASR) output.
+
+      Below is the full, accurate transcript of a recording:
+      <transcript>
+      #{@voice_recording.transcription}
+      </transcript>
+
+      The recording has been segmented into #{entries.size} sequential segments. Each segment's current (possibly inaccurate) ASR transcription is listed below in chronological order:
+      #{existing}
+
+      Using the full accurate transcript as the source of truth, provide the corrected Irish text for each segment in order. The segments together should cover the full transcript.
+
+      Rules:
+      - Return ONLY a valid JSON array of strings, one element per segment, in the same order.
+      - Do not merge or split segments - there must be exactly #{entries.size} elements.
+      - Each element should contain only the Irish text for that segment.
+      - If a segment cannot be matched, return its original ASR text unchanged.
+      - No explanations, no markdown, just the raw JSON array.
+    PROMPT
+
+    client = OpenAI::Client.new(
+      access_token: Rails.application.credentials.dig(:openai, :openai_key),
+      organization_id: Rails.application.credentials.dig(:openai, :openai_org)
+    )
+
+    response = client.chat(parameters: {
+      model: "gpt-4.1",
+      messages: [
+        { role: "system", content: "You are an Irish language expert. Return only valid JSON arrays." },
+        { role: "user", content: prompt }
+      ],
+      temperature: 0.1
+    })
+
+    content = response.dig("choices", 0, "message", "content")
+    return unless content.present?
+
+    # Strip any accidental markdown fences
+    content = content.gsub(/\A```(?:json)?\n?/, "").gsub(/\n?```\z/, "").strip
+    JSON.parse(content)
+  rescue JSON::ParserError => e
+    Rails.logger.error("AutocorrectTranscriptionsService JSON parse error: #{e.message}")
+    nil
+  end
+end

--- a/app/views/voice_recordings/show.html.erb
+++ b/app/views/voice_recordings/show.html.erb
@@ -90,6 +90,16 @@
                       </svg>
                     <% end %>
                   <% end %>
+                  <% if current_user&.admin? && @recording.transcription.present? %>
+                    <%= button_to autocorrect_voice_recording_path(@recording),
+                        class: "text-gray-400 hover:text-green-600 transition-colors flex-shrink-0",
+                        title: "Autocorrect segments using the existing transcript",
+                        form: { data: { turbo_confirm: "This will use the saved transcript to correct all unconfirmed segment transcriptions and re-translate them. Continue?" } } do %>
+                      <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                        <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
+                      </svg>
+                    <% end %>
+                  <% end %>
                 </div>
               <% end %>
             </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,7 @@ Rails.application.routes.draw do
       get :import_status
       get 'subtitles(/:lang)', to: 'voice_recordings#subtitles', defaults: { format: 'vtt' }, as: :subtitles
       post :retranscribe
+      post :autocorrect
     end
     resource :diarization, only: [:create]
   end


### PR DESCRIPTION
## Summary
This PR adds an autocorrect feature that uses OpenAI's GPT-4 to correct machine-generated transcriptions in dictionary entries by comparing them against the full, accurate transcript stored on a VoiceRecording. Corrected entries are then re-translated automatically.

## Key Changes
- **New Service**: `AutocorrectTranscriptionsService` - Uses GPT-4 to intelligently correct ASR output by:
  - Accepting the full accurate transcript as the source of truth
  - Processing dictionary entries in chronological order (by region_start)
  - Skipping confirmed entries and entries with unchanged text
  - Returning corrected text as a JSON array with strict validation
  - Handling JSON parsing errors gracefully with logging

- **New Job**: `AutocorrectTranscriptionsJob` - Background job that:
  - Calls the autocorrect service
  - Re-translates any entries that were updated and lack translations
  - Logs the number of corrected entries

- **Controller Action**: Added `autocorrect` action to `VoiceRecordingsController` that:
  - Requires admin authorization
  - Validates that a transcript exists before processing
  - Enqueues the background job
  - Provides user feedback via flash messages

- **UI**: Added autocorrect button to voice recording show page:
  - Only visible to admins when a transcript is present
  - Includes confirmation dialog explaining the operation
  - Uses a checkmark icon for visual consistency

- **Authorization**: Added `autocorrect?` policy method restricting access to admins only

- **Routing**: Added POST route for the autocorrect action

## Implementation Details
- The service uses a low temperature (0.1) for consistent, deterministic corrections
- Handles markdown fence artifacts in GPT response (```json blocks)
- Maintains segment count validation to ensure no segments are merged/split
- Logs detailed error messages for debugging API failures
- Gracefully handles missing or blank segments by preserving original ASR text

https://claude.ai/code/session_01DapVS8Cs63NNKAu8uEhFeD