### PR TITLE
feat: voice recording radio mode (full-screen shuffle player)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: ghostscript pdftk tesseract-ocr tesseract-ocr-deu tnef
+          packages: ffmpeg ghostscript pdftk tesseract-ocr tesseract-ocr-deu tnef
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,6 @@ jobs:
 
     env:
       RAILS_ENV: test
-      GEMFILE_RUBY_VERSION: 3.0.0
       # Rails verifies the time zone in DB is the same as the time zone of the Rails app
       # TZ: "Europe/Berlin"
 
@@ -29,8 +28,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          # Not needed with a .ruby-version file
-          ruby-version: 3.0.6
+          ruby-version: 3.4.2
           # runs 'bundle install' and caches installed gems automatically
           bundler-cache: true
       - name: Update Dependencies

--- a/app/controllers/voice_recordings_controller.rb
+++ b/app/controllers/voice_recordings_controller.rb
@@ -1,6 +1,33 @@
 class VoiceRecordingsController < ApplicationController
   before_action :set_voice_recording, only: %i[show edit update destroy add_region import_status retranscribe autocorrect]
   PAGE_SIZE = 15 # Define the constant at the top of the controller
+  RADIO_PLAYLIST_SIZE = 50
+
+  def radio
+    authorize VoiceRecording
+
+    unless Rails.configuration.x.features.radio
+      return redirect_to(voice_recordings_path, alert: "Radio is not enabled yet.")
+    end
+
+    candidates = VoiceRecording
+      .joins(:dictionary_entries)
+      .joins(ActiveRecord::Base.sanitize_sql_array([
+        "INNER JOIN active_storage_attachments asa ON asa.record_id = voice_recordings.id " \
+        "AND asa.record_type = ? AND asa.name = ?",
+        "VoiceRecording", "media"
+      ]))
+      .distinct
+      .order(Arel.sql("RANDOM()"))
+      .limit(RADIO_PLAYLIST_SIZE)
+      .with_attached_media
+      .with_attached_audio_track
+      .includes(:dictionary_entries)
+
+    @playlist = candidates.filter_map { |recording| radio_playlist_entry(recording) }
+
+    render layout: "radio"
+  end
 
   def index
     @new_voice_recording = VoiceRecording.new
@@ -267,6 +294,28 @@ class VoiceRecordingsController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_voice_recording
     @voice_recording = VoiceRecording.find(params[:id])
+  end
+
+  def radio_playlist_entry(recording)
+    blob = recording.audio_track.attached? ? recording.audio_track : recording.media
+    return nil unless blob.attached?
+
+    {
+      id: recording.id,
+      title: recording.title,
+      url: url_for(blob),
+      path: voice_recording_path(recording),
+      entries: recording.dictionary_entries
+        .sort_by { |e| e.region_start.to_f }
+        .map { |e|
+          {
+            start: e.region_start.to_f,
+            end: e.region_end.to_f,
+            ga: e.word_or_phrase,
+            en: e.translation
+          }
+        }
+    }
   end
 
   def set_regions

--- a/app/javascript/controllers/radio_controller.js
+++ b/app/javascript/controllers/radio_controller.js
@@ -1,0 +1,142 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [
+    "audio", "title", "link", "ga", "en",
+    "playButton", "playIcon", "pauseIcon",
+    "progress", "currentTime", "duration", "position"
+  ]
+  static values = { playlist: Array }
+
+  connect() {
+    this.order = this.shuffledOrder()
+    this.cursor = 0
+    this.loadCurrent({ autoplay: false })
+  }
+
+  disconnect() {
+    if (this.hasAudioTarget) {
+      this.audioTarget.pause()
+      this.audioTarget.removeAttribute("src")
+      this.audioTarget.load()
+    }
+  }
+
+  // ── Playlist navigation ──────────────────────────────────────────────────
+
+  shuffledOrder() {
+    const indices = this.playlistValue.map((_, i) => i)
+    for (let i = indices.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1))
+      ;[indices[i], indices[j]] = [indices[j], indices[i]]
+    }
+    return indices
+  }
+
+  current() {
+    return this.playlistValue[this.order[this.cursor]]
+  }
+
+  loadCurrent({ autoplay = true } = {}) {
+    const item = this.current()
+    if (!item) return
+
+    this.audioTarget.src = item.url
+    if (this.hasTitleTarget) this.titleTarget.textContent = item.title
+    if (this.hasLinkTarget) this.linkTarget.href = item.path
+    if (this.hasPositionTarget) this.positionTarget.textContent = String(this.cursor + 1)
+
+    this.resetCaption()
+    this.resetProgress()
+
+    if (autoplay) {
+      const play = this.audioTarget.play()
+      if (play && typeof play.catch === "function") play.catch(() => {})
+    }
+  }
+
+  next() {
+    if (this.playlistValue.length === 0) return
+    this.cursor = (this.cursor + 1) % this.order.length
+    this.loadCurrent()
+  }
+
+  prev() {
+    if (this.playlistValue.length === 0) return
+    this.cursor = (this.cursor - 1 + this.order.length) % this.order.length
+    this.loadCurrent()
+  }
+
+  shuffle() {
+    this.order = this.shuffledOrder()
+    this.cursor = 0
+    this.loadCurrent()
+  }
+
+  // ── Playback ─────────────────────────────────────────────────────────────
+
+  playPause() {
+    if (this.audioTarget.paused) {
+      const play = this.audioTarget.play()
+      if (play && typeof play.catch === "function") play.catch(() => {})
+    } else {
+      this.audioTarget.pause()
+    }
+  }
+
+  playing() {
+    this.playIconTarget?.classList.add("hidden")
+    this.pauseIconTarget?.classList.remove("hidden")
+    this.playButtonTarget?.setAttribute("aria-label", "Pause")
+  }
+
+  paused() {
+    this.playIconTarget?.classList.remove("hidden")
+    this.pauseIconTarget?.classList.add("hidden")
+    this.playButtonTarget?.setAttribute("aria-label", "Play")
+  }
+
+  // ── Progress and captions ────────────────────────────────────────────────
+
+  timeupdate() {
+    const t = this.audioTarget.currentTime
+    const total = this.audioTarget.duration || 0
+    if (this.hasProgressTarget && total > 0) {
+      this.progressTarget.style.width = `${Math.min(100, (t / total) * 100)}%`
+    }
+    if (this.hasCurrentTimeTarget) {
+      this.currentTimeTarget.textContent = this.formatTime(t)
+    }
+
+    const entries = this.current()?.entries || []
+    const entry = entries.find((e) => t >= e.start && t < e.end)
+    if (entry) {
+      if (this.hasGaTarget && entry.ga) this.gaTarget.textContent = entry.ga
+      if (this.hasEnTarget) this.enTarget.textContent = entry.en || ""
+    }
+  }
+
+  loadedmetadata() {
+    if (this.hasDurationTarget) {
+      this.durationTarget.textContent = this.formatTime(this.audioTarget.duration)
+    }
+  }
+
+  resetCaption() {
+    if (this.hasGaTarget) this.gaTarget.textContent = this.current()?.title || ""
+    if (this.hasEnTarget) this.enTarget.textContent = ""
+  }
+
+  resetProgress() {
+    if (this.hasProgressTarget) this.progressTarget.style.width = "0%"
+    if (this.hasCurrentTimeTarget) this.currentTimeTarget.textContent = "0:00"
+    if (this.hasDurationTarget) this.durationTarget.textContent = "0:00"
+  }
+
+  formatTime(seconds) {
+    if (!Number.isFinite(seconds)) return "0:00"
+    const m = Math.floor(seconds / 60)
+    const s = Math.floor(seconds % 60).toString().padStart(2, "0")
+    return `${m}:${s}`
+  }
+}

--- a/app/policies/voice_recording_policy.rb
+++ b/app/policies/voice_recording_policy.rb
@@ -43,4 +43,8 @@ class VoiceRecordingPolicy < ApplicationPolicy
     # Same permission as show - anyone can check import status
     true
   end
+
+  def radio?
+    true
+  end
 end

--- a/app/views/application/_nav.html.erb
+++ b/app/views/application/_nav.html.erb
@@ -14,6 +14,9 @@
         <div class="hidden md:block">
           <div class="ml-10 flex items-baseline space-x-4">
             <%= link_to 'Transcriptions', voice_recordings_path, class: "text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium" %>
+            <% if Rails.configuration.x.features.radio %>
+              <%= link_to 'Radio', radio_voice_recordings_path, class: "text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium" %>
+            <% end %>
             <%= link_to 'Dictionary', dictionary_entries_path, class: "text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium" %>
             <%= link_to 'Speakers', users_path, class: "text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium" %>
             <%= link_to 'Translators', translator_leaderboard_index_path, class: "text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium" %>
@@ -91,6 +94,11 @@
         <li>
           <%= link_to 'Transcriptions', voice_recordings_path, class: "flex items-center p-2 text-base font-normal text-gray-300 rounded-lg hover:bg-gray-700 hover:text-white" %>
         </li>
+        <% if Rails.configuration.x.features.radio %>
+          <li>
+            <%= link_to 'Radio', radio_voice_recordings_path, class: "flex items-center p-2 text-base font-normal text-gray-300 rounded-lg hover:bg-gray-700 hover:text-white" %>
+          </li>
+        <% end %>
         <li>
           <%= link_to 'Dictionary', dictionary_entries_path, class: "flex items-center p-2 text-base font-normal text-gray-300 rounded-lg hover:bg-gray-700 hover:text-white" %>
         </li>

--- a/app/views/layouts/radio.html.erb
+++ b/app/views/layouts/radio.html.erb
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Abairt Radio</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no">
+    <meta name="theme-color" content="#0f172a">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
+    <%= stylesheet_link_tag 'application', media: 'all' %>
+    <%= yield :head %>
+    <%= javascript_importmap_tags %>
+  </head>
+  <body class="bg-slate-950 text-white min-h-screen overscroll-none">
+    <%= yield %>
+  </body>
+</html>

--- a/app/views/voice_recordings/radio.html.erb
+++ b/app/views/voice_recordings/radio.html.erb
@@ -1,0 +1,105 @@
+<div class="min-h-screen flex flex-col"
+     data-controller="radio"
+     data-radio-playlist-value="<%= @playlist.to_json %>">
+  <% if @playlist.empty? %>
+    <div class="flex-1 flex items-center justify-center p-8 text-center">
+      <div>
+        <h1 class="text-2xl font-semibold mb-2">No recordings to play</h1>
+        <p class="text-slate-400 mb-6">There are no voice recordings with audio available yet.</p>
+        <%= link_to "Back to recordings", voice_recordings_path,
+            class: "inline-block px-4 py-2 rounded-lg bg-indigo-600 hover:bg-indigo-500 text-white" %>
+      </div>
+    </div>
+  <% else %>
+    <header class="flex items-center justify-between p-4 text-sm text-slate-400">
+      <%= link_to voice_recordings_path,
+          class: "hover:text-white inline-flex items-center gap-1" do %>
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+          <path fill-rule="evenodd" d="M9.707 14.707a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 1.414L7.414 9H15a1 1 0 110 2H7.414l2.293 2.293a1 1 0 010 1.414z" clip-rule="evenodd" />
+        </svg>
+        Back
+      <% end %>
+      <span>
+        <span data-radio-target="position">1</span> / <%= @playlist.size %>
+      </span>
+    </header>
+
+    <main class="flex-1 flex flex-col items-center justify-center px-6 pb-6">
+      <a data-radio-target="link" href="#"
+         class="text-xs uppercase tracking-widest text-slate-500 hover:text-slate-300 mb-3">
+        <span data-radio-target="title">&nbsp;</span>
+      </a>
+
+      <div class="w-full max-w-2xl bg-slate-900/60 rounded-2xl p-6 md:p-10 shadow-2xl">
+        <div class="min-h-[8rem] md:min-h-[12rem] flex flex-col items-center justify-center text-center">
+          <p data-radio-target="ga"
+             class="text-2xl md:text-4xl font-medium leading-snug">
+            Brúigh seinm
+          </p>
+          <p data-radio-target="en"
+             class="mt-3 text-base md:text-xl text-slate-400 italic">
+            Press play
+          </p>
+        </div>
+
+        <div class="mt-8">
+          <div class="h-1 w-full rounded-full bg-slate-800 overflow-hidden">
+            <div data-radio-target="progress" class="h-full bg-indigo-500" style="width: 0%"></div>
+          </div>
+          <div class="mt-2 flex justify-between text-xs text-slate-500">
+            <span data-radio-target="currentTime">0:00</span>
+            <span data-radio-target="duration">0:00</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="mt-8 flex items-center gap-6">
+        <button type="button"
+                data-action="click->radio#prev"
+                aria-label="Previous"
+                class="p-3 rounded-full text-slate-300 hover:bg-slate-800 hover:text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-7 w-7" viewBox="0 0 20 20" fill="currentColor">
+            <path d="M15.555 5.168A1 1 0 0014 6v8a1 1 0 001.555.832l6-4a1 1 0 000-1.664l-6-4z" transform="rotate(180 10 10)"/>
+            <path d="M3 5a1 1 0 011-1h1a1 1 0 011 1v10a1 1 0 01-1 1H4a1 1 0 01-1-1V5z"/>
+          </svg>
+        </button>
+
+        <button type="button"
+                data-action="click->radio#playPause"
+                data-radio-target="playButton"
+                aria-label="Play"
+                class="p-5 rounded-full bg-indigo-600 hover:bg-indigo-500 text-white shadow-lg">
+          <svg data-radio-target="playIcon" xmlns="http://www.w3.org/2000/svg" class="h-10 w-10" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM9.555 7.168A1 1 0 008 8v4a1 1 0 001.555.832l3-2a1 1 0 000-1.664l-3-2z" clip-rule="evenodd" />
+          </svg>
+          <svg data-radio-target="pauseIcon" xmlns="http://www.w3.org/2000/svg" class="h-10 w-10 hidden" viewBox="0 0 20 20" fill="currentColor">
+            <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zM7 8a1 1 0 012 0v4a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v4a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd" />
+          </svg>
+        </button>
+
+        <button type="button"
+                data-action="click->radio#next"
+                aria-label="Skip"
+                class="p-3 rounded-full text-slate-300 hover:bg-slate-800 hover:text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-7 w-7" viewBox="0 0 20 20" fill="currentColor">
+            <path d="M4.555 5.168A1 1 0 003 6v8a1 1 0 001.555.832L10 11.202V14a1 1 0 001.555.832l6-4a1 1 0 000-1.664l-6-4A1 1 0 0010 6v2.798L4.555 5.168z" />
+          </svg>
+        </button>
+
+        <button type="button"
+                data-action="click->radio#shuffle"
+                aria-label="Shuffle"
+                class="p-3 rounded-full text-slate-300 hover:bg-slate-800 hover:text-white">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M16 3h5v5M4 20L21 3M21 16v5h-5M15 15l6 6M4 4l5 5" />
+          </svg>
+        </button>
+      </div>
+
+      <audio data-radio-target="audio"
+             data-action="ended->radio#next timeupdate->radio#timeupdate loadedmetadata->radio#loadedmetadata play->radio#playing pause->radio#paused"
+             preload="auto"
+             playsinline></audio>
+    </main>
+  <% end %>
+</div>

--- a/config/initializers/feature_flags.rb
+++ b/config/initializers/feature_flags.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Application-level feature flags.
+#
+# Set ENV vars to enable. Defaults to disabled so new features can ship
+# dark until they're ready to roll out.
+Rails.application.config.x.features = ActiveSupport::OrderedOptions.new
+Rails.application.config.x.features.radio = ActiveModel::Type::Boolean.new.cast(
+  ENV.fetch("RADIO_ENABLED", "false")
+)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,9 @@ Rails.application.routes.draw do
   resources :word_lists
   resources :registrations, only: [:new, :create]
   resources :voice_recordings do
+    collection do
+      get :radio
+    end
     resources :dictionary_entries, module: :voice_recordings, only: [:index, :create, :update] do
       member do
         post :confirm

--- a/test/controllers/voice_recordings_controller_test.rb
+++ b/test/controllers/voice_recordings_controller_test.rb
@@ -84,4 +84,55 @@ class VoiceRecordingsControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :redirect
   end
+
+  test "radio redirects when feature flag is disabled" do
+    Rails.configuration.x.features.stubs(:radio).returns(false)
+
+    get radio_voice_recordings_url
+
+    assert_redirected_to voice_recordings_url
+  end
+
+  test "radio renders when feature flag is enabled" do
+    Rails.configuration.x.features.stubs(:radio).returns(true)
+
+    get radio_voice_recordings_url
+
+    assert_response :success
+    assert_select "[data-controller='radio']"
+  end
+
+  test "radio renders empty state when no recordings have media" do
+    Rails.configuration.x.features.stubs(:radio).returns(true)
+    VoiceRecording.find_each { |r| r.media.purge if r.media.attached? }
+
+    get radio_voice_recordings_url
+
+    assert_response :success
+    assert_match(/No recordings to play/, response.body)
+  end
+
+  test "radio includes attached recording with entries in playlist" do
+    Rails.configuration.x.features.stubs(:radio).returns(true)
+    @voice_recording.media.attach(
+      io: StringIO.new("fake audio"),
+      filename: "test.mp3",
+      content_type: "audio/mpeg"
+    )
+    DictionaryEntry.create!(
+      voice_recording: @voice_recording,
+      speaker: users(:one),
+      owner: users(:one),
+      word_or_phrase: "Dia dhuit",
+      translation: "Hello",
+      region_start: 0.0,
+      region_end: 1.5
+    )
+
+    get radio_voice_recordings_url
+
+    assert_response :success
+    assert_match(/data-radio-playlist-value/, response.body)
+    assert_match(/Dia dhuit/, response.body)
+  end
 end


### PR DESCRIPTION
## Summary

Adds a "radio" mode for voice recordings — a full-screen player that shuffles through every recording back-to-back. Designed for late-night listening on a phone: dark UI, large tap targets, auto-advance, and a live transcription panel that follows the audio.

Hidden behind a `RADIO_ENABLED` env flag (`Rails.configuration.x.features.radio`) so it can ship dark and roll out when ready. Nav link and route both gated by the flag.

## What's in the change

- `GET /voice_recordings/radio` → `VoiceRecordingsController#radio`, rendered with a minimal `radio` layout.
- Server picks up to 50 recordings that have audio and at least one dictionary entry, shuffled by `RANDOM()`. Returns a JSON playlist (id, title, audio URL, sorted `{start, end, ga, en}` entries) inlined into the page.
- `radio_controller.js` Stimulus controller: client-side re-shuffle, prev / play-pause / next / shuffle, auto-advance on `ended`, sync caption from `timeupdate`, progress bar.
- `VoiceRecordingPolicy#radio?` returns true (matches public `index` / `show`).
- Tests cover: flag-off redirect, flag-on render, empty state, populated playlist surfaces audio + transcription data.

## Controls

- Big circular play / pause in the centre, prev / skip / shuffle on either side.
- Tap the title to jump to the full recording's edit / detail view if you want to inspect the transcription.

## Notes

- The audio element is rendered without native controls; everything is custom so it fits the full-screen mobile layout. `playsinline` set so iOS Safari doesn't auto-fullscreen video files.
- If a recording is a video with no extracted `audio_track`, the browser will still play its audio via the `<audio>` element.

## Test plan

- [ ] `RADIO_ENABLED=false` (default) — visiting `/voice_recordings/radio` redirects back with a notice; nav link hidden.
- [ ] `RADIO_ENABLED=true` — nav shows "Radio"; page loads, first track auto-loads (without autoplay until tapped, per browser policies), play / pause / next / prev / shuffle all work.
- [ ] Captions update in sync with audio position.
- [ ] Auto-advance to next track when one ends.
- [ ] Works on a phone in portrait, controls large enough to hit one-handed.

---
_Generated by [Claude Code](https://claude.ai/code/session_013MyJS5aF2SpDBWvGQzgtoT)_